### PR TITLE
fix: netbox's content_types is now named object_types.

### DIFF
--- a/syncer.py
+++ b/syncer.py
@@ -62,7 +62,7 @@ class Syncer:
     def ensure_netbox_custom_field(self, lock: bool = False):
         content_types = ['dcim.device', 'dcim.devicetype', 'dcim.interface', 'dcim.manufacturer', 'dcim.site', 'dcim.devicerole',
                          'dcim.location', 'tenancy.tenant']
-        cufi = {"name": KEY_CUSTOM_FIELD, "display": "Snipe object id", "content_types": content_types,
+        cufi = {"name": KEY_CUSTOM_FIELD, "display": "Snipe object id", "object_types": content_types,
                 "description": "The ID of the original SnipeIT Object used for Sync",
                 "type": "integer", "ui_visibility": "read-only" if lock else "read-write"}
 


### PR DESCRIPTION
In REST API v4.0 NetBox renamed content_types to object_types: https://netboxlabs.com/docs/netbox/en/stable/release-notes/version-4.0/#rest-api-changes

> - extras.CustomField
>     - content_types has been renamed to object_types

This pull request updates the request to reflect this, fixing https://github.com/derlucas/snipeit-netbox/issues/3