### PR TITLE
netbox 4.0 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pynetbox==7.0.1
+pynetbox==7.4.1
 requests==2.31.0
 w3lib~=2.1.0

--- a/syncer.py
+++ b/syncer.py
@@ -462,8 +462,8 @@ class Syncer:
         if nb_site and nb_device['site']['id'] != nb_site['id']:
             update_dict = update_dict | {'site': nb_site['id']}
 
-        if nb_device['device_role']['id'] != nb_role['id']:
-            update_dict = update_dict | {'device_role': nb_role['id']}
+        if nb_device['role']['id'] != nb_role['id']:
+            update_dict = update_dict | {'role': nb_role['id']}
 
         if nb_tenant and nb_device['tenant'] and nb_device['tenant']['id'] != nb_tenant['id']:
             update_dict = update_dict | {'tenant': nb_tenant['id']}


### PR DESCRIPTION
After upgrading netbox to 4.0 i've got this error:

`ERROR:root:'device_role'`

The field "device_role" was renamed in Rel 4.0 of Netbox https://github.com/netbox-community/netbox/releases/tag/v4.0.0

[PyNetbox](https://github.com/netbox-community/pynetbox) also requires a newer version to be Netbox 4 compatible.